### PR TITLE
Update make file to use immediate set for build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ ifndef IMAGE_REPO
 	IMAGE_REPO=theotw
 endif
 BASE_VERSION := $(shell cat 'version.txt')
-BUILD_DATE=$(shell date '+%Y%m%d%H%M')
+BUILD_DATE := $(shell date '+%Y%m%d%H%M')
 
-BUILD_VERSION=${BASE_VERSION}.${BUILD_DATE}
+BUILD_VERSION := ${BASE_VERSION}.${BUILD_DATE}
 ifndef IMAGE_TAG
-	IMAGE_TAG=${BUILD_VERSION}
+	IMAGE_TAG := ${BUILD_VERSION}
 endif
 
 


### PR DESCRIPTION
Update the BUILD_DATE to use an immediate set (`:=`) instead of the lazy set (`=`).
The lazy set is causing a new build version to be created every time BUILD_DATE is referenced.