### PR TITLE
Fix transfer of keyID on certificate rotation

### DIFF
--- a/pkg/cloudserver/api_impl.go
+++ b/pkg/cloudserver/api_impl.go
@@ -497,7 +497,6 @@ func handlePostCertRotation(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, "")
 		return
 	}
-
 	pubKeyBits, err := msgs.PullMessageFromEnvelope(&in.PublicKeyPackage)
 
 	if err != nil {
@@ -527,6 +526,18 @@ func handlePostCertRotation(c *gin.Context) {
 	}
 
 	existingLocationData.SetKeyPair(pubKeyBits, nil).UpdateLastKeyPairRotation()
+	if err = existingLocationData.SetKeyID(in.KeyID); err != nil {
+		code, ret := bridgemodel.HandleErrors(c, err)
+		c.JSON(code, &ret)
+		return
+	}
+
+	err = store.RemoveLocation(existingLocationData.GetLocationID())
+	if err != nil {
+		code, ret := bridgemodel.HandleErrors(c, err)
+		c.JSON(code, &ret)
+		return
+	}
 
 	err = store.WriteLocation(*existingLocationData)
 	if err != nil {

--- a/pkg/msgs/cert_rotation_schema.go
+++ b/pkg/msgs/cert_rotation_schema.go
@@ -5,6 +5,7 @@ import (
 )
 
 type CertRotationRequest struct {
+	KeyID            string           `json:"keyID,omitempty"`
 	PublicKeyPackage MessageEnvelope  `json:"publicKey,omitempty"`
 	PremID           string           `json:"premID,omitempty"`
 	AuthChallenge    v1.AuthChallenge `json:"authChallenge,omitempty"`

--- a/pkg/persistence/mongo/mongo_key_store.go
+++ b/pkg/persistence/mongo/mongo_key_store.go
@@ -32,7 +32,7 @@ func (m *MongoKeyStore) initCollections() error {
 	_, err := locCol.Indexes().CreateOne(
 		context.TODO(),
 		mongo.IndexModel{
-			Keys:    bson.D{{"id", 1}},
+			Keys:    bson.D{{"locationID", 1}},
 			Options: options.Index().SetUnique(true),
 		},
 	)
@@ -44,7 +44,7 @@ func (m *MongoKeyStore) initCollections() error {
 	_, err = kpCol.Indexes().CreateOne(
 		context.TODO(),
 		mongo.IndexModel{
-			Keys:    bson.D{{"locationID", 1}},
+			Keys:    bson.D{{"keyID", 1}},
 			Options: options.Index().SetUnique(true),
 		},
 	)


### PR DESCRIPTION
closes cert-rotation-bug
* Updates mongo key store to fix index fields.
* Fix transfer of new KeyID from natssync-client to natssync-server on cert rotation.
* Updates persistence cleanup to delete keys create before the current key.