### PR TITLE
feat: add SKIP_TLS_VALIDATION flag to client

### DIFF
--- a/k8sconfig/client.yaml
+++ b/k8sconfig/client.yaml
@@ -8,6 +8,7 @@ data:
   cloud_bridge_url: "http://message-bridge.hcieng.com"
   key_store: "file:///data"
   log_leve: "trace"
+  skip_tls_validation: "true"
 
 ---
 apiVersion: v1
@@ -92,6 +93,11 @@ spec:
             configMapKeyRef:
               name: natsync-client-config
               key: key_store
+        - name: SKIP_TLS_VALIDATION
+          valueFrom:
+            configMapKeyRef:
+              name: natsync-client-config
+              key: skip_tls_validation
 
 
 ---

--- a/k8sconfig/client.yaml
+++ b/k8sconfig/client.yaml
@@ -8,7 +8,7 @@ data:
   cloud_bridge_url: "http://message-bridge.hcieng.com"
   key_store: "file:///data"
   log_leve: "trace"
-  skip_tls_validation: "true"
+  skip_tls_validation: "false"
 
 ---
 apiVersion: v1

--- a/pkg/bridgeclient/app.go
+++ b/pkg/bridgeclient/app.go
@@ -72,6 +72,12 @@ func RunClient(test bool) {
 	if msgFormat == nil {
 		log.Fatalf("Unable to get the message format")
 	}
+
+	if pkg.Config.SkipTlsValidation {
+		log.Warn("SKIP_TLS_VALIDATION was set to true! Don't use this in production!")
+		bridgemodel.ConfigureDefaultTransportToSkipTlsValidation()
+	}
+
 	if err := RunBridgeClientRestAPI(); err != nil {
 		log.Errorf("Error starting API server %s", err.Error())
 		os.Exit(1)

--- a/pkg/bridgemodel/utils.go
+++ b/pkg/bridgemodel/utils.go
@@ -68,7 +68,7 @@ func (t *HttpClient) sendAuthorizedRequest(method string, url string, body []byt
 	return
 }
 
-func ConfigureDefaultTransport() {
+func ConfigureDefaultTransportToSkipTlsValidation() {
 	// allows calls to https
 	dt := http.DefaultTransport
 	switch dt.(type) {

--- a/pkg/configuration.go
+++ b/pkg/configuration.go
@@ -20,12 +20,13 @@ const (
 var Config Configuration
 
 type Configuration struct {
-	NatsServerUrl  string
-	CloudBridgeUrl string
-	LogLevel       string
-	KeystoreUrl    string
-	ListenString   string
-	CloudEvents    bool
+	NatsServerUrl     string
+	CloudBridgeUrl    string
+	LogLevel          string
+	KeystoreUrl       string
+	ListenString      string
+	CloudEvents       bool
+	SkipTlsValidation bool
 }
 
 type configOption struct {
@@ -42,6 +43,7 @@ func (c *Configuration) LoadValues() {
 		{&c.KeystoreUrl, "KEYSTORE_URL", "file:///tmp"},
 		{&c.ListenString, "LISTEN_STRING", ":8080"},
 		{&c.CloudEvents, "CLOUDEVENTS_ENABLED", false},
+		{&c.SkipTlsValidation, "SKIP_TLS_VALIDATION", false},
 	}
 
 	for _, option := range configOptions {


### PR DESCRIPTION
This adds a flag that allows us to skip TLS validation when the client makes https requests. It currently modifies the default transport, which is not ideal, but it's a quick and neat-ish solution for the moment. It's for development purposes only, of course.