### PR TITLE
Make  max length of buffer to be read data from TCP socket configurable

### DIFF
--- a/pkg/httpsproxy/README.md
+++ b/pkg/httpsproxy/README.md
@@ -4,3 +4,6 @@
 * Default locationID for the proxy server is `proxy`
 
 the Default ID for both services can be updated by setting `DEFAULT_LOCATION_ID` environment variable  
+
+## Max bytes read from tcp socket 
+* this value can be updated by setting env variable `MAX_BYTES_TCP` defaults to 1024 bytes


### PR DESCRIPTION
closes tcp-socket-max-len
* updated the max length of buffer to be read data from TCP socket configurable