### PR TITLE
feat: add mongodb config via env vars

### DIFF
--- a/pkg/configuration.go
+++ b/pkg/configuration.go
@@ -26,6 +26,10 @@ type Configuration struct {
 	CloudBridgeUrl    string
 	LogLevel          string
 	KeystoreUrl       string
+	MongodbServer     string
+	MongodbPort       string
+	MongodbUsername   string
+	MongodbPassword   string
 	ListenString      string
 	ConfigmapName     string
 	PodNamespace      string
@@ -45,6 +49,10 @@ func (c *Configuration) LoadValues() {
 		{&c.CloudBridgeUrl, "CLOUD_BRIDGE_URL", "http://localhost:8081"},
 		{&c.LogLevel, "LOG_LEVEL", "debug"},
 		{&c.KeystoreUrl, "KEYSTORE_URL", "file:///tmp"},
+		{&c.MongodbServer, "MONGODB_SERVER", ""},
+		{&c.MongodbPort, "MONGODB_PORT", "27017"},
+		{&c.MongodbUsername, "MONGODB_USERNAME", ""},
+		{&c.MongodbPassword, "MONGODB_PASSWORD", ""},
 		{&c.ListenString, "LISTEN_STRING", ":8080"},
 		{&c.ConfigmapName, "CONFIGMAP_NAME", ""},
 		{&c.CloudEvents, "CLOUDEVENTS_ENABLED", false},

--- a/pkg/persistence/mongo/mongo_key_store.go
+++ b/pkg/persistence/mongo/mongo_key_store.go
@@ -261,7 +261,7 @@ func (m *MongoKeyStore) ListKnownClients() ([]string, error) {
 
 func NewMongoKeyStore(mongoUri string) (*MongoKeyStore, error) {
 	mongoUrl := fmt.Sprintf("mongodb://%s", mongoUri)
-	log.Debugf("Connecting to mongo at %s", mongoUrl)
+	log.Tracef("Connecting to mongo at %s", mongoUrl)
 
 	keyStore := MongoKeyStore{
 		options:                 options.Client().ApplyURI(mongoUrl),

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -56,6 +56,24 @@ func parseKeystoreUrl(keystoreUrl string) (string, string, error) {
 	return ksType, ksUrl, nil
 }
 
+func buildMongoUrl(config pkg.Configuration, scrubPassword bool) string {
+	var password string
+
+	if scrubPassword {
+		password = "****"
+	} else {
+		password = config.MongodbPassword
+	}
+
+	return fmt.Sprintf(
+		"%s%s:%s@%s:%s",
+		mongoKeyStoreTypePrefix,
+		config.MongodbUsername,
+		password,
+		config.MongodbServer,
+		config.MongodbPort)
+}
+
 func CreateLocationKeyStore(keystoreUrl string) (LocationKeyStore, error) {
 	keystoreType, keystoreUri, err := parseKeystoreUrl(keystoreUrl)
 	if err != nil {
@@ -96,14 +114,8 @@ func InitLocationKeyStore() error {
 	log.Debug("Checking if we should use MongoDB")
 	if pkg.Config.MongodbServer != "" {
 		if pkg.Config.MongodbUsername != "" {
-			log.Debug("MongodbServer and MongodbUsername provided, using MongoDB")
-			keystoreUrl = fmt.Sprintf(
-				"%s%s:%s@%s:%s",
-				mongoKeyStoreTypePrefix,
-				pkg.Config.MongodbUsername,
-				pkg.Config.MongodbPassword,
-				pkg.Config.MongodbServer,
-				pkg.Config.MongodbPort)
+			log.Debugf("MongodbServer and MongodbUsername provided, using MongoDB (url=%s)", buildMongoUrl(pkg.Config, true))
+			keystoreUrl = buildMongoUrl(pkg.Config, false)
 		} else {
 			log.Warnf("MongodbServer was set without MongodbUsername; falling back to KeystoreUrl")
 		}


### PR DESCRIPTION
This PR adds mongodb environment variables:
- `MONGODB_SERVER`
- `MONGODB_PORT`
- `MONGODB_USERNAME`
- `MONGODB_PASSWORD`

This allows a consumer of natssync charts to store the mongodb password inside a k8s secret; previously, we instead had to provide the entire mongo url (including username/pw) through `KEYSTORE_URL` which prevented the use of a k8s secret.

To know whether to use the mongodb config or the keystore URL, we check for `MONGODB_SERVER` and `MONGODB_USERNAME`.