### PR TITLE
fix: encode mongodb password

### DIFF
--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/theotw/natssync/pkg/persistence/configmap"
+	"net/url"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -62,7 +63,7 @@ func buildMongoUrl(config pkg.Configuration, scrubPassword bool) string {
 	if scrubPassword {
 		password = "****"
 	} else {
-		password = config.MongodbPassword
+		password = url.QueryEscape(config.MongodbPassword)
 	}
 
 	return fmt.Sprintf(


### PR DESCRIPTION
This fixes natssync-server crashing when using a mongodb password with icky characters like `:` by encoding them. Tested this locally by deploying without fix, having the error occur, and then re-deploying with the fix.