### PR TITLE
Modify the configmap key store file to read data using the k8s client…

### DIFF
--- a/pkg/bridgeclient/app.go
+++ b/pkg/bridgeclient/app.go
@@ -108,7 +108,7 @@ func RunClient(test bool) {
 
 		nc := natsmodel.GetNatsConnection()
 		clientID := store.LoadLocationID("")
-		//no client ID yet?  that happens on a new startup before it is registered.  Just hang out and wait for one
+		// no client ID yet?  that happens on a new startup before it is registered.  Just hang out and wait for one
 		if len(clientID) == 0 {
 			log.Infof("No client ID, sleeping and retrying")
 			time.Sleep(5 * time.Second)
@@ -127,6 +127,11 @@ func RunClient(test bool) {
 			currentMessageHandler = NewBidiMessageHandler(serverURL)
 			log.Infof("Starting Message Handler of type %s ", currentMessageHandler.GetHandlerType())
 			currentMessageHandler.StartMessageHandler(clientID)
+		}
+
+		if len(clientID) > 0 {
+			// We have a clientID, but we still should wait 5 seconds before running again.
+			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -97,7 +97,7 @@ func CreateLocationKeyStore(keystoreUrl string) (LocationKeyStore, error) {
 		return mongoKeyStore, err
 
 	case configmapKeyStoreTypePrefix:
-		configmapKeyStore, err := configmap.NewConfigmapKeyStore(keystoreUri)
+		configmapKeyStore, err := configmap.NewConfigmapKeyStore()
 		if err == nil {
 			newReaper(configmapKeyStore).RunCleanupJob(context.TODO())
 		}

--- a/tests/misc/configmap_key_store_test.go
+++ b/tests/misc/configmap_key_store_test.go
@@ -23,10 +23,7 @@ type testCase struct {
 }
 
 func TestFileKeyStore(t *testing.T) {
-	// Set to the configmap mount location
-	configmapMountPath := "/configmap-data"
-
-	store, err := configmap.NewConfigmapKeyStore(configmapMountPath)
+	store, err := configmap.NewConfigmapKeyStore()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
During testing I noticed the clientID was not being found until ~30 seconds - 1 minute after it was added to the config map during the registration. The fix was to use the k8s client to get the data from the configmap rather than trying to read from the file system directly.

### Log output:

Here we can see that almost immediately after the registration happens we are able to set up the REST message handler and start sending/receiving messages.

```
k logs -n astra-connector natssync-client-5949959b75-7tghr -f
time="2024-02-01T19:36:49Z" level=info msg="Version 2.2.202402011931" source="bridge_client.go:19"
time="2024-02-01T19:36:49Z" level=info msg="Starting NATSSync Client"
time="2024-02-01T19:36:49Z" level=info msg="Connecting to NATS on nats://nats.astra-connector:4222"
time="2024-02-01T19:36:49Z" level=info msg="Connected to NATS on nats://nats.astra-connector:4222"
time="2024-02-01T19:36:49Z" level=info msg="Leaving NATS Init "
time="2024-02-01T19:36:49Z" level=info msg="Build date: 2.2.202402011931"
time="2024-02-01T19:36:49Z" level=debug msg="Checking if we should use MongoDB"
time="2024-02-01T19:36:49Z" level=warning msg="SKIP_TLS_VALIDATION was set to true! Don't use this in production!"
time="2024-02-01T19:36:49Z" level=info msg="setting up cleanup interval: 1h0m0s"
time="2024-02-01T19:36:49Z" level=info msg="Starting REST API Server"
time="2024-02-01T19:36:49Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:36:49Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:36:54Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:36:54Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:36:59Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:36:59Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:37:04Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:37:04Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:37:09Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:37:09Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:37:14Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-02-01T19:37:14Z" level=info msg="No client ID, sleeping and retrying"
time="2024-02-01T19:37:17Z" level=debug msg="Handling registration post request"
time="2024-02-01T19:37:17Z" level=info msg="Generating new key pair"
time="2024-02-01T19:37:17Z" level=info msg="Registering with cloud server https://integration.astra.netapp.io/bridge-server/1/register/"
time="2024-02-01T19:37:17Z" level=debug msg="Registration response status code 201"
time="2024-02-01T19:37:17Z" level=debug msg="Registration response body {%!s(*http.http2clientStream=&{0xc0005d4480 0xc0000d0000 <nil> <nil> 3 {{0 0} {{} 0xc0006121b0 {0 0 0 <nil> <nil>} 824640086504} 0xc000410640 0 0xc0000ae080 <nil> <nil> 0x779b80} true false {0 {0 0}} 0xc0001cc600 <nil> 0xc0001cc5a0 0xc0001cc6c0 <nil> 0xc0001cc660 0xc000692480 {[] 1047746 0xc0005d44e0} {[] 4193775 0xc0005d44f0} 529 <nil> 0xc0005946d8 830 true true true true true false 0 true false map[] 0xc0006924f8})}"
[GIN] 2024/02/01 - 19:37:17 | 201 |  379.453198ms |     10.42.4.174 | POST     "/bridge-client/1/register"
time="2024-02-01T19:37:19Z" level=info msg="Starting Message Handler of type rest "
time="2024-02-01T19:37:23Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-02-01T19:37:23Z" level=info msg="Received 1 messages from server"
time="2024-02-01T19:37:23Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-02-01T19:37:23Z" level=info msg="Received message: sub=natssyncmsg.54fb89b0-b391-4d47-87ad-068618758413.nautilus.resource.response reply="
time="2024-02-01T19:37:23Z" level=info msg="Publishing data to sub=natssyncmsg.54fb89b0-b391-4d47-87ad-068618758413.nautilus.resource.response"
time="2024-02-01T19:37:24Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-02-01T19:37:24Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-02-01T19:37:24Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-02-01T19:37:24Z" level=info msg="Cloud Events disabled, skipping message validation"
```

### Previous:

Notice the 30 seconds after registration before we start the message handler

```
k logs -n astra-connector natssync-client-65b87967b-rnz26 
time="2024-01-30T21:28:12Z" level=info msg="Version 2.1.202309262121" source="bridge_client.go:19"
time="2024-01-30T21:28:12Z" level=info msg="Starting NATSSync Client"
time="2024-01-30T21:28:12Z" level=info msg="Connecting to NATS on nats://nats.astra-connector:4222"
time="2024-01-30T21:28:12Z" level=info msg="Connected to NATS on nats://nats.astra-connector:4222"
time="2024-01-30T21:28:12Z" level=info msg="Leaving NATS Init "
time="2024-01-30T21:28:12Z" level=info msg="Build date: 2.1.202309262121"
time="2024-01-30T21:28:12Z" level=debug msg="Checking if we should use MongoDB"
time="2024-01-30T21:28:12Z" level=warning msg="SKIP_TLS_VALIDATION was set to true! Don't use this in production!"
time="2024-01-30T21:28:12Z" level=info msg="Starting REST API Server"
time="2024-01-30T21:28:12Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:12Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:12Z" level=info msg="setting up cleanup interval: 1h0m0s"
time="2024-01-30T21:28:17Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:17Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:22Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:22Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:27Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:27Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:32Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:32Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:37Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:37Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:42Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:42Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:47Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:47Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:52Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:52Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:28:57Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:28:57Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:02Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:02Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:07Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:07Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:12Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:12Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:17Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:17Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:22Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:22Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:27Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:27Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:32Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:32Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:37Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:37Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:42Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:42Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:47Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:47Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:52Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:52Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:29:53Z" level=debug msg="Handling registration post request"
time="2024-01-30T21:29:53Z" level=info msg="Generating new key pair"
time="2024-01-30T21:29:53Z" level=info msg="Registering with cloud server https://integration.astra.netapp.io/bridge-server/1/register/"
time="2024-01-30T21:29:54Z" level=debug msg="Registration response status code 201"
time="2024-01-30T21:29:54Z" level=debug msg="Registration response body {%!s(*http.http2clientStream=&{0xc0000d0a80 0xc000134000 <nil> <nil> 3 {{0 0} {{} 0xc0000d1230 {0 0 0 <nil> <nil>} 824634577512} 0xc000438980 0 0xc00011e060 <nil> <nil> 0x779b80} true false {0 {0 0}} 0xc0000c4ae0 <nil> 0xc0000c4a80 0xc0000c4ba0 <nil> 0xc0000c4b40 0xc0004ba240 {[] 1047746 0xc0000d0ae0} {[] 4193775 0xc0000d0af0} 529 <nil> 0xc000010210 830 true true true true true false 0 true false map[] 0xc0004ba2b8})}"
[GIN] 2024/01/30 - 21:29:54 | 201 |   472.31893ms |      10.42.5.40 | POST     "/bridge-client/1/register"
time="2024-01-30T21:29:57Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:29:57Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:02Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:02Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:07Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:07Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:12Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:12Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:17Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:17Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:22Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:22Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:27Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:27Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:32Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:32Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:37Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:37Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:42Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:42Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:47Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:47Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:52Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:52Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:30:57Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:30:57Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:31:02Z" level=error msg="failed get latest keyID" error="existing keys not found"
time="2024-01-30T21:31:02Z" level=info msg="No client ID, sleeping and retrying"
time="2024-01-30T21:31:07Z" level=info msg="Starting Message Handler of type rest "
time="2024-01-30T21:31:10Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:10Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:10Z" level=info msg="Received 1 messages from server"
time="2024-01-30T21:31:10Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:10Z" level=info msg="Received message: sub=natssyncmsg.e18fa2ac-ffba-42a2-8cb6-800bf8a55f56.nautilus.resource.response reply="
time="2024-01-30T21:31:10Z" level=info msg="Publishing data to sub=natssyncmsg.e18fa2ac-ffba-42a2-8cb6-800bf8a55f56.nautilus.resource.response"
time="2024-01-30T21:31:10Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:11Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:11Z" level=info msg="Cloud Events disabled, skipping message validation"
time="2024-01-30T21:31:11Z" level=info msg="Cloud Events disabled, skipping message validation"
```